### PR TITLE
fix php 7.4 join(): Passing glue string after array is deprecated.

### DIFF
--- a/lib/MultiPartForm.php
+++ b/lib/MultiPartForm.php
@@ -118,11 +118,11 @@ class MultiPartForm
 
         // Flatten the list and add closing boundary marker,
         // then return CR+LF separated data
-        $parts = array_map(function($val) {return join($val, "\r\n");}, $parts);
+        $parts = array_map(function($val) {return implode("\r\n", $val);}, $parts);
         $end_boundary = $part_boundary . "--";
         array_push($parts, $end_boundary);
 
-        return join($parts, "\r\n");
+        return implode("\r\n", $parts);
     }
 }
 ?>


### PR DESCRIPTION
This package will report an error when running on php 7.4

error file to MultiPartForm.php Line 121 and 125

![image](https://user-images.githubusercontent.com/7987563/73051323-73c12400-3ebd-11ea-9cb8-b696bc14a016.png)

```
join(): Passing glue string after array is deprecated.
```